### PR TITLE
bloop: add JAVA_OPTS support to bloop server

### DIFF
--- a/pkgs/development/tools/build-managers/bloop/default.nix
+++ b/pkgs/development/tools/build-managers/bloop/default.nix
@@ -2,7 +2,7 @@
 
 let
   baseName = "bloop";
-  version = "1.2.5";
+  version = "1.3.2";
   deps = stdenv.mkDerivation {
     name = "${baseName}-deps-${version}";
     buildCommand = ''
@@ -16,14 +16,14 @@ let
     '';
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash     = "19373fyb0g7irrdzb1vsjmyv5xj84qwbcfb6lm076px7wfyn0w1c";
+    outputHash     = "1npq02npk6qiwghgr3bqd1ala1kv8hwq1qkmyffvigcq7frkz4r8";
   };
 in
 stdenv.mkDerivation rec {
   name = "${baseName}-${version}";
 
   # Fetched from https://github.com/scalacenter/bloop/releases/download/v${version}/install.py
-  nailgunCommit = "0c325237";
+  nailgunCommit = "9327a60a";
 
   buildInputs = [ jdk makeWrapper deps ];
 
@@ -31,12 +31,12 @@ stdenv.mkDerivation rec {
 
   client = fetchurl {
     url = "https://raw.githubusercontent.com/scalacenter/nailgun/${nailgunCommit}/pynailgun/ng.py";
-    sha256 = "0qjw4nsyb4cxg96jj1yv5c0ivcxvmscxxqfzll5w9p1pjb30bq0n";
+    sha256 = "0z4as5ibmzkd145wsch9caiy4037bgg780gcf7pyns0cv9n955b4";
   };
 
   zshCompletion = fetchurl {
     url = "https://raw.githubusercontent.com/scalacenter/bloop/v${version}/etc/zsh/_bloop";
-    sha256 = "1id6f1fgy2rk0q5aad6ffivhbxa94fallzsc04l9n0y1s2xdhqpm";
+    sha256 = "09qq5888vaqlqan2jbs2qajz2c3ff13zj8r0x2pcxsqmvlqr02hp";
   };
 
   installPhase = ''

--- a/pkgs/development/tools/build-managers/bloop/default.nix
+++ b/pkgs/development/tools/build-managers/bloop/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
 
     makeWrapper ${jre}/bin/java $out/bin/blp-server \
       --prefix PATH : ${lib.makeBinPath [ jdk ]} \
-      --add-flags "-cp $CLASSPATH bloop.Server"
+      --add-flags "-cp $CLASSPATH \$JAVA_OPTS bloop.Server"
     makeWrapper ${client} $out/bin/bloop \
       --prefix PATH : ${lib.makeBinPath [ python ]}
   '';

--- a/pkgs/development/tools/build-managers/bloop/default.nix
+++ b/pkgs/development/tools/build-managers/bloop/default.nix
@@ -3,6 +3,8 @@
 let
   baseName = "bloop";
   version = "1.3.2";
+  nailgunCommit = "9327a60a"; # Fetched from https://github.com/scalacenter/bloop/releases/download/v${version}/install.py
+
   deps = stdenv.mkDerivation {
     name = "${baseName}-deps-${version}";
     buildCommand = ''
@@ -18,39 +20,53 @@ let
     outputHashAlgo = "sha256";
     outputHash     = "1npq02npk6qiwghgr3bqd1ala1kv8hwq1qkmyffvigcq7frkz4r8";
   };
+
+  client = stdenv.mkDerivation {
+    name = "${baseName}-client-${nailgunCommit}";
+
+    src = fetchurl {
+      url = "https://raw.githubusercontent.com/scalacenter/nailgun/${nailgunCommit}/pynailgun/ng.py";
+      sha256 = "0z4as5ibmzkd145wsch9caiy4037bgg780gcf7pyns0cv9n955b4";
+    };
+
+    phases = [ "installPhase" ];
+
+    installPhase = ''
+      cp $src $out
+      chmod +x $out
+    '';
+  };
+
+  zsh = stdenv.mkDerivation {
+    name = "${baseName}-zshcompletion-${version}";
+
+    src = fetchurl {
+      url = "https://raw.githubusercontent.com/scalacenter/bloop/v${version}/etc/zsh/_bloop";
+      sha256 = "09qq5888vaqlqan2jbs2qajz2c3ff13zj8r0x2pcxsqmvlqr02hp";
+    };
+
+    phases = [ "installPhase" ];
+
+    installPhase = ''cp $src $out'';
+  };
 in
 stdenv.mkDerivation rec {
   name = "${baseName}-${version}";
-
-  # Fetched from https://github.com/scalacenter/bloop/releases/download/v${version}/install.py
-  nailgunCommit = "9327a60a";
 
   buildInputs = [ jdk makeWrapper deps ];
 
   phases = [ "installPhase" ];
 
-  client = fetchurl {
-    url = "https://raw.githubusercontent.com/scalacenter/nailgun/${nailgunCommit}/pynailgun/ng.py";
-    sha256 = "0z4as5ibmzkd145wsch9caiy4037bgg780gcf7pyns0cv9n955b4";
-  };
-
-  zshCompletion = fetchurl {
-    url = "https://raw.githubusercontent.com/scalacenter/bloop/v${version}/etc/zsh/_bloop";
-    sha256 = "09qq5888vaqlqan2jbs2qajz2c3ff13zj8r0x2pcxsqmvlqr02hp";
-  };
-
   installPhase = ''
     mkdir -p $out/bin
     mkdir -p $out/share/zsh/site-functions
 
-    cp ${client} $out/bin/blp-client
-    cp ${zshCompletion} $out/share/zsh/site-functions/_bloop
-    chmod +x $out/bin/blp-client
+    ln -s ${zsh} $out/share/zsh/site-functions/_bloop
 
     makeWrapper ${jre}/bin/java $out/bin/blp-server \
       --prefix PATH : ${lib.makeBinPath [ jdk ]} \
       --add-flags "-cp $CLASSPATH bloop.Server"
-    makeWrapper $out/bin/blp-client $out/bin/bloop \
+    makeWrapper ${client} $out/bin/bloop \
       --prefix PATH : ${lib.makeBinPath [ python ]}
   '';
 


### PR DESCRIPTION
###### Motivation for this change

added JAVA_OPTS to allow settings java parameters to the server (such as Xss, Xmx etc). thought I could add it to your PR. No worries if you prefer to keep it separate - I can send a new PR once yours is merged :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
